### PR TITLE
update menu css for good pages in order to avoid focus loss when menu is hidden

### DIFF
--- a/apply.html
+++ b/apply.html
@@ -13,6 +13,8 @@
             type="text/css" rel="stylesheet">
 
     <style>
+        #menu {display:none;}
+        #layout.active #menu {display:block;}
         #menu .pure-menu-selected, #menu .pure-menu-heading {
             color: #fff;
         }
@@ -30,6 +32,9 @@
 
         body:hover .visually-hidden a, body:hover .visually-hidden input, body:hover .visually-hidden button {
             display: none !important;
+        }
+        @media (min-width: 48em) {
+            #menu {display: block;}
         }
     </style>
 

--- a/content-good.html
+++ b/content-good.html
@@ -7,13 +7,15 @@
 
     <title>About Acme | Acme Widgets</title>
 
-    
+
 
 
 <link rel="stylesheet" href="css/pure.css">
 <link href="https://rawgithub.com/tilomitra/csstypography/master/css/pure-typography.css" type="text/css" rel="stylesheet">
 
 <style>
+#menu {display:none;}
+#layout.active #menu {display:block;}
 #menu .pure-menu-selected, #menu .pure-menu-heading {color:#fff;}
 .visually-hidden {
 position: absolute !important;
@@ -30,25 +32,28 @@ body:hover .visually-hidden input,
 body:hover .visually-hidden button {
 display: none !important;
 }
+@media (min-width: 48em) {
+    #menu {display: block;}
+}
 </style>
 
 
 
 
 
-  
+
     <!--[if lte IE 8]>
         <link rel="stylesheet" href="css/layouts/side-menu-old-ie.css">
     <![endif]-->
     <!--[if gt IE 8]><!-->
         <link rel="stylesheet" href="css/layouts/side-menu.css">
     <!--<![endif]-->
-  
 
 
-    
 
-    
+
+
+
 
 </head>
 <body>
@@ -93,10 +98,10 @@ display: none !important;
             <p>Acme Widgets <img src="images/coyote.png" alt="Wile E. Coyote" style="float:right"> is best known for its role in the Roadrunner cartoons. Acme has proudly provided genius widgets to help the coyote capture the roadrunner. While our widgets are fabulous, the low success rate is certainly due to user error. </p>
             <p>Here's an interesting tidbit, not everybody roots for the Roadrunner. This graph shows the breakdown. <br>
             <a href="https://hbr.org/2009/08/coyotes-vs-road-runners-managi"><img src="images/graph-beherens.gif" alt="survey of people rooting for the coyote or roadrunner broken down by race" longdesc="https://hbr.org/2009/08/coyotes-vs-road-runners-managi"></a></p>
-            
+
             <h2>Using this page</h2>
             <p>
-                This is a <strong>sample page</strong> that includes <em>many</em> elements that are used to give content semantic value. You should be able to run automated tests agains this page and have no errors. Here's a list of elements within this page: 
+                This is a <strong>sample page</strong> that includes <em>many</em> elements that are used to give content semantic value. You should be able to run automated tests agains this page and have no errors. Here's a list of elements within this page:
             </p>
             <h3>Lists</h3>
             <ul class="list">
@@ -104,12 +109,12 @@ display: none !important;
             <li>Ordered list</li>
             <li><abbr title="Definition List">DL</abbr></li>
             <li>Headers</li>
-            <li>Blockquote with cite</li> 
+            <li>Blockquote with cite</li>
             <li>Image with alt text</li>
             <li>Image with long description</li>
-            <li>Inline tags: abbr, strong, em, del, ins, time</li> 
+            <li>Inline tags: abbr, strong, em, del, ins, time</li>
             </ul>
-            
+
             <h4>Ordered and Definition Lists</h4>
             <p>Help make Acme better</p>
             <ol class="list">
@@ -127,10 +132,10 @@ display: none !important;
             <dt>Pull Request</dt>
             <dd>Ask the project manager to include your <del datetime="2015-11-16">code</del> <ins datetime="2015-11-16">patch</ins> into the project.</dd>
             </dl>
-            
-            
-            
-            
+
+
+
+
             <p>This page was originally created on <time datetime="2015-11-16">November 16, 2015</time>.</p>
 </div>
           </article>

--- a/data-good.html
+++ b/data-good.html
@@ -11,6 +11,8 @@
 <link href="https://rawgithub.com/tilomitra/csstypography/master/css/pure-typography.css" type="text/css" rel="stylesheet">
 
 <style>
+#menu {display:none;}
+#layout.active #menu {display:block;}
 #menu .pure-menu-selected, #menu .pure-menu-heading {color:#fff;}
 .visually-hidden {
 position: absolute !important;
@@ -33,7 +35,7 @@ display: none !important;
     {
         display: table;
     }
-   
+
     [role="row"]
     {
         display: table-row;
@@ -50,6 +52,10 @@ display: none !important;
 		background:#e0e0e0;
 		color:#000;
 	}
+
+@media (min-width: 48em) {
+    #menu {display: block;}
+}
 
 </style>
 
@@ -87,7 +93,7 @@ display: none !important;
     </div>
 
     <main id="main">
-        
+
          <header class="header">
             <h1>Acme Widgets</h1>
         </header>
@@ -95,7 +101,7 @@ display: none !important;
         <div class="content">
             <h2 class="content-subhead">Choose the right widget for you</h2>
             <p>
-                Acme widgets is more than just anvils. Choose the right tool for your job. 
+                Acme widgets is more than just anvils. Choose the right tool for your job.
             </p>
             <p>This page includes <strong>fully accessible data tables</strong>. Your automated tests should not trigger any errors.</p>
             <h3>Compare Acme Widgets</h3>
@@ -136,7 +142,7 @@ display: none !important;
             </tr>
             </tbody>
             </table>
-            
+
             <h3>Last order</h3>
             <table summary="invoice"  class="pure-table pure-table-bordered">
             <caption>Order from October 25, 2015</caption>
@@ -215,7 +221,7 @@ $19.99
 </div>
 </div>
            </div>
-           
+
     </main>
 </div>
 


### PR DESCRIPTION
When hidden, focus is lost in the off-canvas menu. This PR just adds a some small inline CSS to hide the menu via `display:none` so that keyboard focus will not traverse the menu.
